### PR TITLE
feat: Initial content for OCI to create the cve-checker image based on trivy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+VERSION ?= 1.0.0-dev
+CONTAINER_MANAGER ?= podman
+
+# Image URL to use all building/pushing image targets
+IMG ?= quay.io/redhat-aipcc/cve-checker:v${VERSION}
+
+# Build for amd64 architecture only
+.PHONY: oci-build
+oci-build: 
+	${CONTAINER_MANAGER} build -t $(IMG) -f oci/Containerfile ./oci
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # cve-checker
+
+This tool allows to compare 2 image versions and return 2 files:
+
+* fixed.txt which contains the list of CVEs fixed within the new version
+* new.txt which contains the new CVEs found in the new image
+
+## Build
+
+To build the container with latest dbs run the command:
+
+```
+make oci-build
+```
+
+## Usage
+
+To access private registries we need to setup the AUTH envs.
+
+```bash
+podman run -it --rm \
+    -v $PWD:/data:z \
+    -e AUTH_REG="quay.io" \
+    -e AUTH_USER="XXX" \
+    -e AUTH_PASS="XXXX" \
+    -e BASE_IMAGE="quay.io/aipcc/rhaiis/cuda-ubi9:3.2.0" \
+    -e TARGET_IMAGE="quay.io/modh/vllm@sha256:280c1be54ab687df0e88f926389ac03697607b09a95bf9f68859d5b90342e83f" \
+    -e OUTPUT_PATH=/data \
+    quay.io/redhat-aipcc/cve-checker:v1.0.0-dev
+
+```

--- a/oci/Containerfile
+++ b/oci/Containerfile
@@ -1,0 +1,23 @@
+FROM registry.access.redhat.com/ubi9/ubi@sha256:8f1496d50a66e41433031bf5bdedd4635520e692ccd76ffcb649cf9d30d669af
+
+ENV TRIVY_VERSION 0.66.0 
+
+RUN dnf install -y skopeo jq \
+    && curl -LO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
+    && tar -xzvf trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz trivy LICENSE \
+    && mv trivy /usr/local/bin \
+    && mv LICENSE /usr/local/bin/trivy-LICENSE \
+    && rm trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz \
+    && trivy image --download-db-only \
+    && trivy image --download-java-db-only
+
+# OCI image is intended to work unmutable
+# If we need new db we will create new images each day with same 
+# trivy version
+ENV TRIVY_SKIP_DB_UPDATE true
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+

--- a/oci/entrypoint.sh
+++ b/oci/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -z "$BASE_IMAGE" || -z "$TARGET_IMAGE" || -z "$OUTPUT_PATH" ]]; then
+  echo "BASE_IMAGE and TARGET_IMAGE are mandatory."
+  exit 1
+fi
+
+if [[ -n "${AUTH_USER:-}" && -n "${AUTH_PASS:-}" && -n "${AUTH_REG:-}" ]]; then
+  echo "$AUTH_PASS" | skopeo login --username "$AUTH_USER" --password-stdin "$AUTH_REG"
+fi
+
+# Get Images
+BASE_IMAGE_PATH=/base
+TARGET_IMAGE_PATH=/target
+skopeo copy --insecure-policy "docker://${BASE_IMAGE}" "oci:${BASE_IMAGE_PATH}:latest"
+skopeo copy --insecure-policy "docker://${TARGET_IMAGE}" "oci:${TARGET_IMAGE_PATH}:latest"
+# Analyze
+mkdir /compare
+pushd /compare
+trivy image --input ${BASE_IMAGE_PATH} --no-progress --format json -o base.json
+trivy image --input ${TARGET_IMAGE_PATH} --no-progress --format json -o target.json
+# Extract
+jq '.Results[].Vulnerabilities[]?.VulnerabilityID' base.json | sort > base-vulns.txt
+jq '.Results[].Vulnerabilities[]?.VulnerabilityID' target.json | sort > target-vulns.txt
+
+comm -23 base-vulns.txt target-vulns.txt > "${OUTPUT_PATH}/fixed.txt"
+comm -13 base-vulns.txt target-vulns.txt > "${OUTPUT_PATH}/new.txt"


### PR DESCRIPTION
This PR includes an initial commit to create an OCI image based on Trivy which is able to compare 2 images (base and target) in order to generate 2 files:

* fixed file with a list of CVEs fixed on target image
* new file with a list of new CVEs on the target image